### PR TITLE
Allow building with base-4.15.*

### DIFF
--- a/functor-classes-compat.cabal
+++ b/functor-classes-compat.cabal
@@ -87,7 +87,7 @@ library
   -- The order is chosen so 'f f' combination is only requiring src-old
   if flag(base-transformers-1)
     if flag(base-transformers-2)
-      build-depends: base >=4.9 && <4.15
+      build-depends: base >=4.9 && <4.16
 
     else
       build-depends:


### PR DESCRIPTION
GHC 9.0 bundles this version of `base`, so this is needed for 9.0 support.